### PR TITLE
added descriptions to clarify difference links

### DIFF
--- a/src/components/UrlContainer.js
+++ b/src/components/UrlContainer.js
@@ -1,4 +1,5 @@
-import { Button, Divider, Grid, TextField, Typography } from "@mui/material";
+import { Button, Divider, Grid, IconButton, TextField, Tooltip, Typography } from "@mui/material";
+import HelpIcon from '@mui/icons-material/Help';
 import React, { useState } from "react";
 
 const UrlContainer = ({ tourUrl, fullUrl }) => {
@@ -18,8 +19,13 @@ const UrlContainer = ({ tourUrl, fullUrl }) => {
             {tourUrl !== "" && tourUrl !== undefined && (
                 <>
                     <Divider sx={{ width: "100%" }} />
-                    <Grid item xs={12}>
-                        <Typography variant="subtitle1">Short URL:</Typography>
+                    <Grid item xs={12} sx={{ display: "flex", alignItems: "center" }}>
+                        <Typography variant="subtitle1">Short Link (For tour viewers)</Typography>
+                        <Tooltip title="Redirects user to the room of the tour, does NOT contain the images/videos.">
+                            <IconButton size="small">
+                                <HelpIcon />
+                            </IconButton>
+                        </Tooltip>
                     </Grid>
                     <Grid item xs={9}>
                         <TextField
@@ -48,8 +54,13 @@ const UrlContainer = ({ tourUrl, fullUrl }) => {
                 fullUrl !== "" && fullUrl !== undefined && (
                     <>
                         <Divider sx={{ width: "100%", py: "8px" }} />
-                        <Grid item xs={12}>
-                            <Typography variant="subtitle1">Full URL:</Typography>
+                        <Grid item xs={12} sx={{ display: "flex", alignItems: "center" }}>
+                            <Typography variant="subtitle1">Full Link: (For Tour Creators)</Typography>
+                            <Tooltip title="Link to create a new tour room with all the images/videos included.">
+                                <IconButton size="small">
+                                    <HelpIcon />
+                                </IconButton>
+                            </Tooltip>
                         </Grid>
                         <Grid item xs={9}>
                             <TextField


### PR DESCRIPTION
Users are unaware of the differences between the link shortened by Cuttly and the original link.

Short Link (For Tour Viewers):
Link shortened by Cuttly, redirects the user to the room of the tour. Does NOT contain the images

Original Link (For Tour Creators):
Full link that can be copy and pasted to create a new tour room with all the images included.